### PR TITLE
Complete logged out bookmarking and dependent destroy bugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'omniauth-google-oauth2'
 gem 'will_paginate'
 gem 'acts-as-taggable-on', '~> 6.0'
 gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census"
-
+gem 'omniauth-github'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
+    omniauth-github (1.4.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-google-oauth2 (0.8.0)
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
@@ -394,6 +397,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   omniauth-census!
+  omniauth-github
   omniauth-google-oauth2
   orderly
   pg (>= 0.18, < 2.0)

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -10,3 +10,21 @@
 .btn:hover {
   background-color: transparent;
 }
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  color: black;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,5 @@
 class Tutorial < ApplicationRecord
-  has_many :videos, -> { order(position: :ASC) }, inverse_of: :tutorial
+  has_many :videos, -> { order(position: :ASC) }, inverse_of: :tutorial, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 end

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -21,7 +21,7 @@
       <% else %>
         <div class="tooltip">
           <span class="tooltiptext">In order to bookmark a video, you must log in!</span>
-          <%= link_to "Bookmark", class: "btn btn-outline mb1 teal" %>
+          <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
         </div>
       <% end %>
     </div>

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -19,7 +19,10 @@
       <% if current_user %>
       <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
       <% else %>
-      <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+        <div class="tooltip">
+          <span class="tooltiptext">In order to bookmark a video, you must log in!</span>
+          <%= link_to "Bookmark", class: "btn btn-outline mb1 teal" %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,28 +9,28 @@ prework_tutorial = Tutorial.create! prework_tutorial_data
 
 prework_tutorial.videos.create!({
   "title"=>"Prework - Environment Setup",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"qMkRHW9zE1c",
   "thumbnail"=>"https://i.ytimg.com/vi/qMkRHW9zE1c/hqdefault.jpg",
   "position"=>1
 })
 prework_tutorial.videos.create!({
   "title"=>"Prework - SSH Key Setup",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"XsPVWGKK0qI",
   "thumbnail"=>"https://i.ytimg.com/vi/XsPVWGKK0qI/hqdefault.jpg",
   "position"=>2
 })
 prework_tutorial.videos.create!({
   "title"=>"Prework - Strings",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"iXLwXvev4X8",
   "thumbnail"=>"https://i.ytimg.com/vi/iXLwXvev4X8/hqdefault.jpg",
   "position"=>3
 })
 prework_tutorial.videos.create!({
   "title"=>"Prework - Arrays",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"c2UnIQ3LRnM",
   "thumbnail"=>"https://i.ytimg.com/vi/c2UnIQ3LRnM/hqdefault.jpg",
   "position"=>4
@@ -49,14 +49,14 @@ m1_tutorial = Tutorial.create! mod_1_tutorial_data
 
 m1_tutorial.videos.create!({
   "title"=>"Flow Control in Ruby",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"tZDBWXZzLPk",
   "thumbnail"=>"https://i.ytimg.com/vi/tZDBWXZzLPk/hqdefault.jpg",
   "position"=>1
 })
 m1_tutorial.videos.create!({
   "title"=>"How to use SimpleCov",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"WMgDD2lU5nY",
   "thumbnail"=>"https://i.ytimg.com/vi/WMgDD2lU5nY/hqdefault.jpg",
   "position"=>2
@@ -74,42 +74,42 @@ m3_tutorial = Tutorial.create! mod_3_tutorial_data
 
 m3_tutorial.videos.create!({
   "title"=>"Customizing JSON in your API",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"cv1VQ_9OqvE",
   "thumbnail"=>"https://i.ytimg.com/vi/cv1VQ_9OqvE/hqdefault.jpg",
   "position"=>1
 })
 m3_tutorial.videos.create!({
   "title"=>"Rails Integration Testing",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"J7ikFUlkP_k",
   "thumbnail"=>"https://i.ytimg.com/vi/J7ikFUlkP_k/hqdefault.jpg",
   "position"=>2
 })
 m3_tutorial.videos.create!({
   "title"=>"BEE - M3 - Building An Internal API",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"R5FPYQgB6Zc",
   "thumbnail"=>"https://i.ytimg.com/vi/R5FPYQgB6Zc/hqdefault.jpg",
   "position"=>3
 })
 m3_tutorial.videos.create!({
   "title"=>"Stubbing External API Calls in Rails",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"FUYoJTtfJ20",
   "thumbnail"=>"https://i.ytimg.com/vi/FUYoJTtfJ20/hqdefault.jpg",
   "position"=>4
 })
 m3_tutorial.videos.create!({
   "title"=>"B3 - Making Fetch Happen",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"lqx4sD0E6eY",
   "thumbnail"=>"https://i.ytimg.com/vi/lqx4sD0E6eY/hqdefault.jpg",
   "position"=>5
 })
 m3_tutorial.videos.create!({
   "title"=>"BDD - Consuming an API",
-  "description"=> Faker::Hipster.paragraph(2, true),
+  "description"=> Faker::Hipster.paragraph(sentence_count: 2, supplemental: true),
   "video_id"=>"FcgkfZEv_LI",
   "thumbnail"=>"https://i.ytimg.com/vi/FcgkfZEv_LI/hqdefault.jpg",
   "position"=>6

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -1,20 +1,35 @@
 require 'rails_helper'
 
 feature "An admin can delete a tutorial" do
-  scenario "and it should no longer exist" do
+  before :each do 
     admin = create(:admin)
+    @tutorial = create(:tutorial)
     create_list(:tutorial, 2)
-
+    @video1 = create(:video, tutorial_id: @tutorial.id)
+    @video2 = create(:video, tutorial_id: @tutorial.id)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
-
     visit "/admin/dashboard"
+  end
 
-    expect(page).to have_css('.admin-tutorial-card', count: 2)
+  scenario "and it should no longer exist" do
+    expect(page).to have_css('.admin-tutorial-card', count: 3)
 
     within(first('.admin-tutorial-card')) do
       click_link 'Delete'
     end
 
-    expect(page).to have_css('.admin-tutorial-card', count: 1)
+    expect(page).to have_css('.admin-tutorial-card', count: 2)
+  end
+
+  scenario "and it's associated videos are deleted as well." do 
+    expect(page).to have_css('.admin-tutorial-card', count: 3)
+    
+    within(first('.admin-tutorial-card')) do
+      click_link('Delete')
+    end
+
+    expect(page).to have_css('.admin-tutorial-card', count: 2)
+    expect(@tutorial.videos).to eq([])
+    expect(@video1.nil?).to eq(false)
   end
 end

--- a/spec/features/user/user_can_bookmark_a_video_spec.rb
+++ b/spec/features/user/user_can_bookmark_a_video_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'A registered user' do
   it 'can add videos to their bookmarks' do
-    tutorial= create(:tutorial, title: "How to Tie Your Shoes")
+    tutorial = create(:tutorial, title: "How to Tie Your Shoes")
     video = create(:video, title: "The Bunny Ears Technique", tutorial: tutorial)
     user = create(:user)
 
@@ -30,5 +30,15 @@ describe 'A registered user' do
     expect(page).to have_content("Bookmark added to your dashboard")
     click_on 'Bookmark'
     expect(page).to have_content("Already in your bookmarks")
+  end
+
+  it "I seea tooltip when hovering over the bookmark link that login is required to bookmark a video.", :js do
+    tutorial = create(:tutorial)
+    video = create(:video, tutorial_id: tutorial.id)
+
+    visit tutorial_path(tutorial)
+
+    find('.tooltip').hover
+    expect(page).to have_content("In order to bookmark a video, you must log in!")
   end
 end


### PR DESCRIPTION
Made the following changes:
 - Added tests to 1) destroy relationship between tutorials and videos when a tutorial is deleted and 2) check that tooltip is displayed when hovering over bookmark link when not logged in
 - Updated seed file based on a depreciation notice that popped up when running rails db:seed
 - Added CSS for tooltip, tooltip text, and tooltip hover
 - Added tooltip div and span to Tutorial Show page
 - Added 'omniauth-github' gem and updated Gemfile.lock